### PR TITLE
Fix the bugs occurring in the Superhero API when retrieving hero data

### DIFF
--- a/app/src/Controller/SuperHeroController.php
+++ b/app/src/Controller/SuperHeroController.php
@@ -32,16 +32,7 @@ class SuperHeroController extends AbstractController
         $power = $this->superheroService->getSuperpower($hero);
         $battleCry = $this->superheroService->getBattleCry($hero);
         $powerLevel = $this->superheroService->getPowerLevel($hero);
-
-        $universe = match (get_class($hero)) {
-            'App\Hero\Goku' => 'Dragon Ball Z',
-            'App\Hero\IncredibleHulk' => 'Marvel',
-            'App\Hero\IronMan' => 'Marvel',
-            'App\Hero\SpiderMan' => 'Marvel',
-            'App\Hero\Thor' => 'Marvel',
-            'App\Hero\Vegeta' => 'Dragon Ball Z',
-            'App\Hero\Wolverine' => 'Marvel',
-        };
+        $universe = $this->superheroService->getUniverse($hero);
 
         return new JsonResponse([
             'name' => $heroRequested,

--- a/app/src/Controller/SuperHeroController.php
+++ b/app/src/Controller/SuperHeroController.php
@@ -36,7 +36,7 @@ class SuperHeroController extends AbstractController
         $universe = match (get_class($hero)) {
             'App\Hero\Goku' => 'Dragon Ball Z',
             'App\Hero\IncredibleHulk' => 'Marvel',
-            'App\Hero\Ironman' => 'Marvel',
+            'App\Hero\IronMan' => 'Marvel',
             'App\Hero\SpiderMan' => 'Marvel',
             'App\Hero\Thor' => 'Marvel',
             'App\Hero\Vegeta' => 'Dragon Ball Z',

--- a/app/src/Controller/SuperHeroController.php
+++ b/app/src/Controller/SuperHeroController.php
@@ -26,6 +26,15 @@ class SuperHeroController extends AbstractController
         // Retrieve 'hero' from query string
         $heroRequested = $request->query->get('hero');
 
+        // Validate hero request
+        $validHeros = ['hulk', 'ironman', 'spiderman', 'thor', 'wolverine', 'goku', 'vegeta'];
+
+        if($heroRequested === null || !in_array($heroRequested, $validHeros)){
+            return new JsonResponse([
+                'error' => 'Invalid hero name. Choose from: ' . implode(', ', $validHeros)
+            ]);
+        }
+
         // Get the hero requested
         $hero = $this->superheroService->getSuperHero($heroRequested);
 

--- a/app/src/Controller/SuperHeroController.php
+++ b/app/src/Controller/SuperHeroController.php
@@ -43,7 +43,12 @@ class SuperHeroController extends AbstractController
             'App\Hero\Wolverine' => 'Marvel',
         };
 
-        // TODO: return a json object, not a string
-        return new JsonResponse("{$heroRequested} {$universe} {$power}, {$battleCry}, {$powerLevel}");
+        return new JsonResponse([
+            'name' => $heroRequested,
+            'superpower' => $power,
+            'battleCry' => $battleCry,
+            'powerLevel' => $powerLevel,
+            'universe' => $universe,
+        ]);
     }
 }

--- a/app/src/Controller/SuperHeroController.php
+++ b/app/src/Controller/SuperHeroController.php
@@ -27,7 +27,7 @@ class SuperHeroController extends AbstractController
         $heroRequested = $request->query->get('hero');
 
         // Get the hero requested
-        $hero = $this->superheroService->getSuperHero();
+        $hero = $this->superheroService->getSuperHero($heroRequested);
 
         $power = $this->superheroService->getSuperpower($hero);
         $battleCry = $this->superheroService->getBattleCry($hero);

--- a/app/src/Controller/SuperHeroController.php
+++ b/app/src/Controller/SuperHeroController.php
@@ -27,11 +27,11 @@ class SuperHeroController extends AbstractController
         $heroRequested = $request->query->get('hero');
 
         // Validate hero request
-        $validHeros = ['hulk', 'ironman', 'spiderman', 'thor', 'wolverine', 'goku', 'vegeta'];
+        $validHeroes = ['hulk', 'ironman', 'spiderman', 'thor', 'wolverine', 'goku', 'vegeta'];
 
-        if($heroRequested === null || !in_array($heroRequested, $validHeros)){
+        if($heroRequested === null || !in_array($heroRequested, $validHeroes)){
             return new JsonResponse([
-                'error' => 'Invalid hero name. Choose from: ' . implode(', ', $validHeros)
+                'error' => 'Invalid hero name. Choose from: ' . implode(', ', $validHeroes)
             ]);
         }
 

--- a/app/src/Hero/Goku.php
+++ b/app/src/Hero/Goku.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace App\Hero;
 
-class Goku
+use App\Interface\SuperheroInterface;
+
+class Goku implements SuperheroInterface
 {
     public function getSuperpower(): string
     {
@@ -19,5 +21,10 @@ class Goku
     public function getPowerLevel(): string
     {
         return 'high';
+    }
+
+    public function getUniverse(): string
+    {
+        return 'Dragon Ball Z';
     }
 }

--- a/app/src/Hero/IncredibleHulk.php
+++ b/app/src/Hero/IncredibleHulk.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace App\Hero;
 
-class IncredibleHulk
+use App\Interface\SuperheroInterface;
+
+class IncredibleHulk implements SuperheroInterface
 {
     public function getSuperpower(): string
     {
@@ -19,5 +21,10 @@ class IncredibleHulk
     public function getPowerLevel(): string
     {
         return 'high';
+    }
+
+    public function getUniverse(): string
+    {
+        return 'Marvel';
     }
 }

--- a/app/src/Hero/IronMan.php
+++ b/app/src/Hero/IronMan.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace App\Hero;
 
-class IronMan
+use App\Interface\SuperheroInterface;
+
+class IronMan implements SuperheroInterface
 {
     public function getSuperpower(): string
     {
@@ -19,5 +21,10 @@ class IronMan
     public function getPowerLevel(): string
     {
         return 'medium';
+    }
+
+    public function getUniverse(): string
+    {
+        return 'Marvel';
     }
 }

--- a/app/src/Hero/SpiderMan.php
+++ b/app/src/Hero/SpiderMan.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace App\Hero;
 
-class SpiderMan
+use App\Interface\SuperheroInterface;
+
+class SpiderMan implements SuperheroInterface
 {
     public function getSuperpower(): string
     {
@@ -19,5 +21,10 @@ class SpiderMan
     public function getPowerLevel(): string
     {
         return 'medium';
+    }
+
+    public function getUniverse(): string
+    {
+        return 'Marvel';
     }
 }

--- a/app/src/Hero/Thor.php
+++ b/app/src/Hero/Thor.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace App\Hero;
 
-class Thor
+use App\Interface\SuperheroInterface;
+
+class Thor implements SuperheroInterface
 {
     public function getSuperpower(): string
     {
@@ -19,5 +21,10 @@ class Thor
     public function getPowerLevel(): string
     {
         return 'high';
+    }
+
+    public function getUniverse(): string
+    {
+        return 'Marvel';
     }
 }

--- a/app/src/Hero/Vegeta.php
+++ b/app/src/Hero/Vegeta.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace App\Hero;
 
-class Vegeta
+use App\Interface\SuperheroInterface;
+
+class Vegeta implements SuperheroInterface
 {
     public function getSuperpower(): string
     {
@@ -27,5 +29,10 @@ class Vegeta
     public function getPowerLevel(): string
     {
         return 'high';
+    }
+
+    public function getUniverse(): string
+    {
+        return 'Dragon Ball Z';
     }
 }

--- a/app/src/Hero/Vegeta.php
+++ b/app/src/Hero/Vegeta.php
@@ -13,13 +13,15 @@ class Vegeta
 
     public function getBattleCry(): string
     {
-        return array_rand([
+        $battleCries = [
             'Final Flash!',
             'Big Bang Attack!',
             'Galick Gun!',
             'It\'s over 9000!',
             'I am the prince of all Saiyans!'
-        ]);
+        ];
+
+        return $battleCries[array_rand($battleCries)];
     }
 
     public function getPowerLevel(): string

--- a/app/src/Hero/Wolverine.php
+++ b/app/src/Hero/Wolverine.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace App\Hero;
 
-class Wolverine
+use App\Interface\SuperheroInterface;
+
+class Wolverine implements SuperheroInterface
 {
     public function getSuperpower(): string
     {
@@ -19,5 +21,10 @@ class Wolverine
     public function getPowerLevel(): string
     {
         return 'high';
+    }
+
+    public function getUniverse(): string
+    {
+        return 'Marvel';
     }
 }

--- a/app/src/Interface/SuperheroInterface.php
+++ b/app/src/Interface/SuperheroInterface.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Interface;
+
+interface SuperheroInterface
+{
+    public function getSuperpower(): string;
+    public function getBattleCry(): string;
+    public function getPowerLevel(): string;
+    public function getUniverse(): string;
+}

--- a/app/src/Service/SuperheroService.php
+++ b/app/src/Service/SuperheroService.php
@@ -11,6 +11,7 @@ use App\Hero\SpiderMan;
 use App\Hero\Thor;
 use App\Hero\Vegeta;
 use App\Hero\Wolverine;
+use App\Interface\SuperheroInterface;
 
 readonly class SuperheroService
 {
@@ -26,7 +27,7 @@ readonly class SuperheroService
     {
     }
 
-    public function getSuperHero(string $heroName): IncredibleHulk|IronMan|SpiderMan|Thor|Wolverine|Goku|Vegeta
+    public function getSuperHero(string $heroName): SuperheroInterface
     {
         $heroes = [
             'hulk' => $this->incredibleHulk,
@@ -41,27 +42,23 @@ readonly class SuperheroService
         return $heroes[$heroName];
     }
 
-    public function getSuperpower(IncredibleHulk|IronMan|SpiderMan|Thor|Wolverine|Goku|Vegeta $hero): string
+    public function getSuperpower(SuperheroInterface $hero): string
     {
         return $hero->getSuperpower();
     }
 
-    public function getBattleCry(IncredibleHulk|IronMan|SpiderMan|Thor|Wolverine|Goku|Vegeta $hero): string
+    public function getBattleCry(SuperheroInterface $hero): string
     {
         return $hero->getBattleCry();
     }
 
-    public function getPowerLevel(IncredibleHulk|IronMan|SpiderMan|Thor|Wolverine|Goku|Vegeta $hero): string
+    public function getPowerLevel(SuperheroInterface $hero): string
     {
         return $hero->getPowerLevel();
     }
 
-    public function getUniverse(IncredibleHulk|IronMan|SpiderMan|Thor|Wolverine|Goku|Vegeta $hero): string
+    public function getUniverse(SuperheroInterface $hero): string
     {
-        return match (get_class($hero)) {
-            IncredibleHulk::class, IronMan::class, SpiderMan::class, Thor::class, Wolverine::class => 'Marvel',
-            Goku::class, Vegeta::class => 'Dragon Ball Z',
-            default => 'No Universe',
-        };
+        return $hero->getUniverse();
     }
 }

--- a/app/src/Service/SuperheroService.php
+++ b/app/src/Service/SuperheroService.php
@@ -27,19 +27,19 @@ readonly class SuperheroService
     }
 
     // TODO: Get this to return a specific requested hero
-    public function getSuperHero(): IncredibleHulk|IronMan|SpiderMan|Thor|Wolverine|Goku|Vegeta
+    public function getSuperHero(string $heroName): IncredibleHulk|IronMan|SpiderMan|Thor|Wolverine|Goku|Vegeta
     {
         $heroes = [
-            $this->incredibleHulk,
-            $this->ironMan,
-            $this->spiderMan,
-            $this->thor,
-            $this->wolverine,
-            $this->goku,
-            $this->vegeta,
+            'hulk' => $this->incredibleHulk,
+            'ironman' => $this->ironMan,
+            'spiderman' => $this->spiderMan,
+            'thor' => $this->thor,
+            'wolverine' => $this->wolverine,
+            'goku' => $this->goku,
+            'vegeta' => $this->vegeta,
         ];
 
-        return $heroes[array_rand($heroes)];
+        return $heroes[$heroName];
     }
 
     public function getSuperpower(IncredibleHulk|IronMan|SpiderMan|Thor|Wolverine|Goku|Vegeta $hero): string

--- a/app/src/Service/SuperheroService.php
+++ b/app/src/Service/SuperheroService.php
@@ -55,4 +55,13 @@ readonly class SuperheroService
     {
         return $hero->getPowerLevel();
     }
+
+    public function getUniverse(IncredibleHulk|IronMan|SpiderMan|Thor|Wolverine|Goku|Vegeta $hero): string
+    {
+        return match (get_class($hero)) {
+            IncredibleHulk::class, IronMan::class, SpiderMan::class, Thor::class, Wolverine::class => 'Marvel',
+            Goku::class, Vegeta::class => 'Dragon Ball Z',
+            default => 'No Universe',
+        };
+    }
 }

--- a/app/src/Service/SuperheroService.php
+++ b/app/src/Service/SuperheroService.php
@@ -26,7 +26,6 @@ readonly class SuperheroService
     {
     }
 
-    // TODO: Get this to return a specific requested hero
     public function getSuperHero(string $heroName): IncredibleHulk|IronMan|SpiderMan|Thor|Wolverine|Goku|Vegeta
     {
         $heroes = [


### PR DESCRIPTION
# Background

The Superhero API contains various bugs that are causing errors in when the endpoint is called. The bugs are listed below. 

1. Typo in the hard coded class name: `'App\Hero\Ironman' => 'Marvel'`.
2. The `getBattleCry` method in Vegeta returns the array key instead of the value.
3. The `$heroRequested` variable is not being used.
4. Data should be returned as a JSON object. 
5. No error handling. For example, errors are thrown when the hero request is null or the entered hero doesn’t exist.

There is no request validation to prevent rogue data submissions, and no tests to verify that the controller can handle different request scenarios.

# Solution

- Pass the `$heroRequested` variable as an argument to the `getSuperHero` method in the `SuperheroService` to retrieve specific heroes.

- Move the `$universe` logic to the `SuperheroService` and replace the hard coded class names to prevent future typos causing errors.

- Refactor the return value in the `SuperHeroController` to return a structured JSON object instead of a string.

- Implement basic validation in the `SuperHeroController` to only accept specific heroes and return an error early if the request string doesn’t match with any of the `validHeroes` 

- Add a `SuperheroInterface` to define the set of method all heroes must have and to simplifying the process of adding new superheroes. 

# Considerations

For future PRs 

- Move hard coded `universe` values to `enums`
- Add integration testing to check the service works are intended. 
- Add a more robust validation that could sanitise the input and could add some form of rate limiting if this is a public endpoint. 

# Steps to review

1. Run the product using `docker-compose up --build -d`
7. Go to http://localhost:8000/
8. Test the end point with a valid hero (hulk, ironman, spiderman, thor, wolverine, goku, vegeta)
9. Check that the bug listed in the background section are fixed. 
10. Test the end point with an invalid hero (thanos, loki, kang, frieza)
11. Check that an Invalid hero name error is displayed. 
